### PR TITLE
fix get.block background

### DIFF
--- a/R/get.block.R
+++ b/R/get.block.R
@@ -26,10 +26,10 @@ get.block <- function(occ, bg.coords){
 	bvert <- mean(c(max(grp1[, 1]), min(grp2[, 1])))
 	tvert <- mean(c(max(grp3[, 1]), min(grp4[, 1])))
 	horz <- mean(c(max(grpA[, 2]), min(grpB[, 2])))
-	bggrp1 <- bg.coords[bg.coords[, 2] <= horz & bg.coords[, 1]<bvert,]
-	bggrp2 <- bg.coords[bg.coords[, 2] < horz & bg.coords[, 1]>=bvert,]
-	bggrp3 <- bg.coords[bg.coords[, 2] > horz & bg.coords[, 1]<=tvert,]
-	bggrp4 <- bg.coords[bg.coords[, 2] >= horz & bg.coords[, 1]>tvert,]
+	bggrp1 <- bg.coords[bg.coords[, 2] <= horz & bg.coords[, 1] < bvert, ]
+	bggrp2 <- bg.coords[bg.coords[, 2] <= horz & bg.coords[, 1] >= bvert, ]
+	bggrp3 <- bg.coords[bg.coords[, 2] > horz & bg.coords[, 1] <= tvert, ]
+	bggrp4 <- bg.coords[bg.coords[, 2] > horz & bg.coords[, 1] > tvert, ]
 
 	r <- data.frame()
 	if (nrow(grp1) > 0) grp1$grp <- 1; r <- rbind(r, grp1)


### PR DESCRIPTION
Cristhine Vaz, a user of Wallace, was having problems with the get.block. The problem is the logic of background points selection on the get.block function (see picture). Some background points were duplicated when they have the same latitude than the horizontal line (i.e. Grp1 and Grp4). This pull request fixes the problem.

Best,
Gonzalo

![get_block_background](https://user-images.githubusercontent.com/7576183/59545442-c7a96a80-8ee3-11e9-825b-1f06e838d762.jpg)
