### PR TITLE
Update make.args.R

### DIFF
--- a/R/make.args.R
+++ b/R/make.args.R
@@ -13,7 +13,9 @@ make.args <- function(RMvalues=seq(0.5, 4, 0.5), fc=c("L", "LQ", "H", "LQH", "LQ
 			if(!grepl("Q", fc[[i]])) args.list[[i]] <- c(args.list[[i]], "noquadratic")
 			if(!grepl("H", fc[[i]])) args.list[[i]] <- c(args.list[[i]], "nohinge")
 			if(!grepl("P", fc[[i]])) args.list[[i]] <- c(args.list[[i]], "noproduct")
-			if(!grepl("T", fc[[i]])) args.list[[i]] <- c(args.list[[i]], "nothreshold")
+			if(!grepl("T", fc[[i]])) args.list[[i]] <- c(args.list[[i]], "nothreshold") else {
+				args.list[[i]] <- c(args.list[[i]], "threshold")
+			}
 		}
 
 	RM.lab <- rep(RMvalues, each=length(fc))


### PR DESCRIPTION
I noticed that any result of LQHP is the same as its equivalent usign LQHPT, which means that T is not implemented.
Threshold feature is disabled by default in recent versions of Maxent, then to enable it 'threshold' argument should be explicitly mentioned.